### PR TITLE
fixed git URL

### DIFF
--- a/installation_script.sh
+++ b/installation_script.sh
@@ -1,4 +1,4 @@
-git clone https://github.com/cheesema/LibAPR
+git clone https://github.com/cheesema/LibAPR.git
 cd LibAPR
 git submodule update --init --recursive
 cd ..


### PR DESCRIPTION
the URL for pulling the repo was missing a trailing `.git` 
Not sure how the Dockerfile could have worked without it.